### PR TITLE
send batch metrics over http

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,24 @@ Sometimes you might want to hold onto a connection at re-use it, I find this sty
   (:require [cb.cljbeat.opentsdb.core :as tsdb]))
 ```
 ### Use it
+Use a tcp client
 ```
     (let [client (tsdb/open-connection! "metrics.chartbeat.net" 4242)]
       (dotimes [_ 10]
         (tsdb/send-metric client "test.clj-library-dnd" (System/currentTimeMillis) 1337
                       [{:name "type" :value "ogre"} {:name "event" :value "ready"}]))
       (tsdb/close-connection! client))
+```
+Or send batch metrics over http
+```
+    (tsdb/send-metrics-http "metrics.chartbeat.net" 4080 [{:metric "foo"
+                                                           :timestamp (System/currentTimeMillis)
+                                                           :value 1
+                                                           :tags {:host "localhost"
+                                                                  :group "test-group"}}
+                                                          {:metric "bar"
+                                                           :timestamp (System/currentTimeMillis)
+                                                           :value 2}])
 ```
 
 ### Set default tags on your connection

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,8 @@
   :license {:name "BSD 3 Clause"
             :url "http://opensource.org/licenses/BSD-3-Clause"}
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [clj-http "2.0.0"]
+                 [cheshire "5.5.0"]
                  [tcp-server "0.1.0"]]
   :deploy-repositories [["releases" :clojars]]
   :signing {:gpg-key "F0903068"}
@@ -12,5 +14,4 @@
   :profiles {:benchmark {:main com.chartbeat.opentsdb.example_usage}}
   :aliases {"benchmark" ["with-profile" "benchmark" "run"]}
   :vcs :git
-  
 )

--- a/test/com/chartbeat/opentsdb/core_test.clj
+++ b/test/com/chartbeat/opentsdb/core_test.clj
@@ -27,7 +27,7 @@
   "Sets up and tears down a tcp server for the purpose of testing connection code"
   `(let [handler# (fn [reader# writer#] nil)
          server# (tcp/tcp-server :port 5000
-                               :handler (tcp/wrap-io handler#))]
+                                 :handler (tcp/wrap-io handler#))]
       (do (tcp/start server#)
           ~@tests
           (tcp/stop server#))))


### PR DESCRIPTION
Pretty simple to implement. Would've loved to get tests in, by using redefs on the http client to just update an atom with the request contents, but that ended up being a lot more complicated than I think it's worth.

@rmangi 
